### PR TITLE
chore: use absolute imports

### DIFF
--- a/src/assets/js/boot-options.mjs
+++ b/src/assets/js/boot-options.mjs
@@ -1,5 +1,5 @@
 'use strict';
 
-import {initOptions} from "./options.mjs";
+import {initOptions} from "~/js/options.mjs";
 
 initOptions();

--- a/src/assets/js/boot-options.mjs
+++ b/src/assets/js/boot-options.mjs
@@ -1,5 +1,5 @@
 'use strict';
 
-import {initOptions} from "~/js/options.mjs";
+import {initOptions} from "@/options.mjs";
 
 initOptions();

--- a/src/assets/js/boot-popup.mjs
+++ b/src/assets/js/boot-popup.mjs
@@ -1,5 +1,5 @@
 'use strict';
 
-import {initPopup} from "./popup.mjs";
+import {initPopup} from "~/js/popup.mjs";
 
 await initPopup();

--- a/src/assets/js/boot-popup.mjs
+++ b/src/assets/js/boot-popup.mjs
@@ -1,5 +1,5 @@
 'use strict';
 
-import {initPopup} from "~/js/popup.mjs";
+import {initPopup} from "@/popup.mjs";
 
 await initPopup();

--- a/src/assets/js/main.mjs
+++ b/src/assets/js/main.mjs
@@ -3,9 +3,9 @@
 /* global browser */
 
 import 'bootstrap/dist/css/bootstrap.css';
-import '../scss/style.scss';
+import '~/scss/style.scss';
 import 'bootstrap';
-import "../../lib/vendor/normalize-url.js";
+import "lib/vendor/normalize-url.js";
 
 export function assert(condition, msg=undefined) {
   if (!condition)

--- a/src/assets/js/main.mjs
+++ b/src/assets/js/main.mjs
@@ -3,9 +3,10 @@
 /* global browser */
 
 import 'bootstrap/dist/css/bootstrap.css';
-import '~/scss/style.scss';
 import 'bootstrap';
-import "lib/vendor/normalize-url.js";
+
+import '@/scss/style.scss';
+import "@/vendor/normalize-url.js";
 
 export function assert(condition, msg=undefined) {
   if (!condition)

--- a/src/assets/js/options.mjs
+++ b/src/assets/js/options.mjs
@@ -9,7 +9,7 @@ import {
   setButtonWaitState,
   showElement,
   showPage,
-} from "./main.mjs";
+} from "~/js/main.mjs";
 
 const elements = {
   signedInPage: document.querySelector('#signed-in-page'),

--- a/src/assets/js/options.mjs
+++ b/src/assets/js/options.mjs
@@ -9,7 +9,7 @@ import {
   setButtonWaitState,
   showElement,
   showPage,
-} from "~/js/main.mjs";
+} from "@/main.mjs";
 
 const elements = {
   signedInPage: document.querySelector('#signed-in-page'),

--- a/src/assets/js/popup.mjs
+++ b/src/assets/js/popup.mjs
@@ -2,7 +2,7 @@
 
 /* global browser */
 
-import '~/scss/sweetalert-icons.scss';
+import '@/scss/sweetalert-icons.scss';
 
 import {
   assert,

--- a/src/assets/js/popup.mjs
+++ b/src/assets/js/popup.mjs
@@ -2,7 +2,7 @@
 
 /* global browser */
 
-import '../scss/sweetalert-icons.scss';
+import '~/scss/sweetalert-icons.scss';
 
 import {
   assert,

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -79,10 +79,10 @@ module.exports = {
   ],
 
   resolve: {
-    modules: [
-      path.resolve(__dirname, 'src'),
-      'node_modules'
-    ]
+    alias: {
+      '~': path.resolve(__dirname, 'src/assets'),
+      'lib': path.resolve(__dirname, 'src/lib'),
+    },
   },
 
   watchOptions: {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -78,6 +78,13 @@ module.exports = {
     })
   ],
 
+  resolve: {
+    modules: [
+      path.resolve(__dirname, 'src'),
+      'node_modules'
+    ]
+  },
+
   watchOptions: {
     ignored: /node_modules/,
   },

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -80,8 +80,11 @@ module.exports = {
 
   resolve: {
     alias: {
-      '~': path.resolve(__dirname, 'src/assets'),
-      'lib': path.resolve(__dirname, 'src/lib'),
+      '@/options.mjs': path.resolve(__dirname, 'src/assets/js/options.mjs'),
+      '@/popup.mjs': path.resolve(__dirname, 'src/assets/js/popup.mjs'),
+      '@/main.mjs': path.resolve(__dirname, 'src/assets/js/main.mjs'),
+      '@/scss': path.resolve(__dirname, 'src/assets/scss'),
+      '@/vendor': path.resolve(__dirname, 'src/lib/vendor'),
     },
   },
 


### PR DESCRIPTION
* Relative imports from JavaScript files can be cumbersome especially if you're importing multiple levels above the current directory.