### PR TITLE
chore: remove unsecure `console.info` statement

### DIFF
--- a/src/assets/js/options.mjs
+++ b/src/assets/js/options.mjs
@@ -63,7 +63,6 @@ export function initOptions() {
   getUser().then((user) => {
     if (user.token) {
       showPage(elements.signedInPage);
-      console.info(user);
     } else {
       showPage(elements.signInPage);
     }


### PR DESCRIPTION
* The `user` objects contains the token that's stored in the browser session. It should be remove due to security purposes.