### PR TITLE
chore: remove `html-loader`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "eslint-plugin-jasmine": "^4.2.2",
         "file-loader": "^6.2.0",
         "globals": "^15.12.0",
-        "html-loader": "^5.1.0",
         "html-webpack-plugin": "^5.6.3",
         "karma": "^6.4.4",
         "karma-chrome-launcher": "^3.2.0",
@@ -2353,19 +2352,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/envinfo": {
       "version": "7.14.0",
       "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.14.0.tgz",
@@ -3307,49 +3293,6 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
-      }
-    },
-    "node_modules/html-loader": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/html-loader/-/html-loader-5.1.0.tgz",
-      "integrity": "sha512-Jb3xwDbsm0W3qlXrCZwcYqYGnYz55hb6aoKQTlzyZPXsPpi6tHXzAfqalecglMQgNvtEfxrCQPaKT90Irt5XDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "html-minifier-terser": "^7.2.0",
-        "parse5": "^7.1.2"
-      },
-      "engines": {
-        "node": ">= 18.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
-      }
-    },
-    "node_modules/html-minifier-terser": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
-      "integrity": "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "camel-case": "^4.1.2",
-        "clean-css": "~5.3.2",
-        "commander": "^10.0.0",
-        "entities": "^4.4.0",
-        "param-case": "^3.0.4",
-        "relateurl": "^0.2.7",
-        "terser": "^5.15.1"
-      },
-      "bin": {
-        "html-minifier-terser": "cli.js"
-      },
-      "engines": {
-        "node": "^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/html-webpack-plugin": {
@@ -4710,19 +4653,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/parse5": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
-      "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^4.5.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/parseurl": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "eslint-plugin-jasmine": "^4.2.2",
     "file-loader": "^6.2.0",
     "globals": "^15.12.0",
-    "html-loader": "^5.1.0",
     "html-webpack-plugin": "^5.6.3",
     "karma": "^6.4.4",
     "karma-chrome-launcher": "^3.2.0",


### PR DESCRIPTION
* [`html-loader`](https://www.npmjs.com/package/html-loader), not to be confused with [`html-webpack-plugin`](https://www.npmjs.com/package/html-webpack-plugin), is not being used by the project.
  * We only need to use `html-loader` if we are going to import HTML files in our JavaScript files.