### PR TITLE
chore: remove code duplication in the common Webpack config

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -55,14 +55,6 @@ module.exports = {
     new CopyWebpackPlugin({
       patterns: [
         {
-          from: "src/assets/images/screenly-logo*",
-          to: "assets/images/[name][ext]",
-        },
-      ],
-    }),
-    new CopyWebpackPlugin({
-      patterns: [
-        {
           from: "src/lib/vendor/browser-polyfill.min.js",
           to: "lib/vendor/[name][ext]",
         },


### PR DESCRIPTION
### Issues Fixed

> [!NOTE]
> There are no issues associated with this pull request.

### Description

* Removed the duplicate code that copies the images (more specifically, Screenly logos) to the destination

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have tested my changes on Google Chrome.
- [x] I have tested my changes on Mozilla Firefox.
- [x] I added a documentation for the changes I have made (when necessary).

### Additional Information

> [!NOTE]
> The changes don't have a significant impact to the extension's/add-on's look and feel.
