### PR TITLE
fix: make the error (about large cookies) more user-friendly

### DIFF
--- a/src/assets/js/components/popup/proposal.jsx
+++ b/src/assets/js/components/popup/proposal.jsx
@@ -189,7 +189,8 @@ export const Proposal = () => {
       headers = {
         'Cookie': currentProposal.cookieJar.map(
           cookie => cookiejs.serialize(cookie.name, cookie.value)
-        ).join('; ')
+        )
+        .join('; ')
       };
     }
 
@@ -262,6 +263,17 @@ export const Proposal = () => {
                 };
               });
             } else if (!errorJson.type) {
+              if (
+                errorJson.code == '23514' &&
+                errorJson.error == 'Constraint failed.'
+              ) {
+                throw `
+                  Screenly cannot save the web page's credentials because
+                  the cookies are too large. Please try again without
+                  saving the authentication.
+                `;
+              }
+
               throw JSON.stringify(errorJson);
             } else {
               throw 'Unknown error';


### PR DESCRIPTION
### Issues Fixed

* Fixes #66 

### Description

* Made the error message less robotic when the cookies to be saved together with the asset is too large

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have tested my changes on Google Chrome.
- [x] I have tested my changes on Mozilla Firefox.
- [x] I added a documentation for the changes I have made (when necessary).

### Additional Information

#### HTTP Request/Response Details

The `Content-Length` is in bytes.

![http-request-01](https://github.com/user-attachments/assets/537e66d8-6cff-43ff-98bb-0c7ba99fd6cd)
![image](https://github.com/user-attachments/assets/f5a0fd3c-feb0-41c2-b8e6-9eaf2d2d4b99)



#### Screenshot(s)

![Screenshot from 2024-12-10 15-27-23](https://github.com/user-attachments/assets/bab3c653-d7f2-46ba-8141-6a0c88c37379)

