### PR TITLE
fix: don't close the pop-up when opened on a non-HTTP/S page

### DIFF
--- a/src/assets/js/components/popup/proposal.jsx
+++ b/src/assets/js/components/popup/proposal.jsx
@@ -164,7 +164,7 @@ export const Proposal = () => {
 
       await proposeToAddToScreenly(user, pageUrl, pageTitle, cookieJar);
     } catch {
-      window.close();
+      dispatch(openSettings());
     }
   };
 


### PR DESCRIPTION
### Issues Fixed

> [!NOTE]
> No issues are associated with this pull request.

### Description

* The popup doesn't open on non-HTTP/S pagess
* Instead of closing the pop-up, the settings view is shown.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have tested my changes on Google Chrome.
- [x] I have tested my changes on Mozilla Firefox.
- [x] I added a documentation for the changes I have made (when necessary).
