### PR TITLE
chore: remove explicit imports of `React` for components

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -45,6 +45,7 @@ export default [
         ...globals.node,
         Atomics: 'readonly',
         SharedArrayBuffer: 'readonly',
+        React: 'readonly',
       },
 
       ecmaVersion: 'latest',

--- a/src/assets/js/components/popup/popup-spinner.jsx
+++ b/src/assets/js/components/popup/popup-spinner.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 export const PopupSpinner = () => {
   return (
     <div

--- a/src/assets/js/components/popup/proposal.jsx
+++ b/src/assets/js/components/popup/proposal.jsx
@@ -1,6 +1,5 @@
 /* global browser */
 
-import React from 'react';
 import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 

--- a/src/assets/js/components/popup/save-auth-help.jsx
+++ b/src/assets/js/components/popup/save-auth-help.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 export const SaveAuthHelp = () => {
   return (
     <div className="font-italic mb-0 mt-2 text-muted">

--- a/src/assets/js/components/popup/save-auth-warning.jsx
+++ b/src/assets/js/components/popup/save-auth-warning.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useEffect, useState } from 'react';
 
 export const SaveAuthWarning = (props) => {

--- a/src/assets/js/components/popup/settings.jsx
+++ b/src/assets/js/components/popup/settings.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import classNames from 'classnames';

--- a/src/assets/js/components/popup/sign-in-success.jsx
+++ b/src/assets/js/components/popup/sign-in-success.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 export const SignInSuccess = () => {
   return (
     <div className="page" id="success-page">

--- a/src/assets/js/components/popup/sign-in.jsx
+++ b/src/assets/js/components/popup/sign-in.jsx
@@ -1,6 +1,5 @@
 /* global browser */
 
-import React from 'react';
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import classNames from 'classnames';

--- a/src/assets/js/components/popup/success.jsx
+++ b/src/assets/js/components/popup/success.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 export const Success = ({ assetDashboardLink }) => {
   const openAssetDashboard = () => {
     window.open(assetDashboardLink);

--- a/src/assets/js/components/popup/token-help-text.jsx
+++ b/src/assets/js/components/popup/token-help-text.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 export const TokenHelpText = () => {
   return (
     <div className="alert mt-3 mb-1 TokenHelpText">

--- a/src/assets/js/popup.jsx
+++ b/src/assets/js/popup.jsx
@@ -1,5 +1,4 @@
 import ReactDOM from 'react-dom/client';
-import React from 'react';
 import {
   useEffect,
   useState,

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -3,6 +3,7 @@ const CopyWebpackPlugin = require("copy-webpack-plugin");
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const RemovePlugin = require('remove-files-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const webpack = require('webpack');
 
 module.exports = {
   entry: {
@@ -36,6 +37,9 @@ module.exports = {
   },
 
   plugins: [
+    new webpack.ProvidePlugin({
+      React: 'react',
+    }),
     new CopyWebpackPlugin({
       patterns: [
         {


### PR DESCRIPTION
### Issues Fixed

Fixes #77

### Description

Removes explicit imports of `React` for components

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have tested my changes on Google Chrome.
- [x] I have tested my changes on Mozilla Firefox.
- [x] I added a documentation for the changes I have made (when necessary).
