### PR TITLE
chore: initial steps for enforcing Typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "typescript": "^5.3.3",
     "webpack": "^5.96.1",
     "webpack-cli": "^5.1.4",
-    "webpack-merge": "^6.0.1"
+    "webpack-merge": "^6.0.1",
+    "ts-loader": "^9.5.1"
   },
   "scripts": {
     "test": "karma start --single-run --browsers ChromeHeadlessNoSandbox karma.conf.js",

--- a/src/assets/js/popup.tsx
+++ b/src/assets/js/popup.tsx
@@ -21,7 +21,8 @@ import { Settings } from '@/components/settings';
 
 import { store } from '@/store';
 import { signIn } from '@/features/popupSlice';
-import { RootState } from '@/types';
+
+import { RootState } from '@/store';
 
 interface CustomEvent extends Event {
   detail: string;

--- a/src/assets/js/store.js
+++ b/src/assets/js/store.js
@@ -7,3 +7,5 @@ export const store = configureStore({
     popup: popupReducer,
   },
 });
+
+export type RootState = ReturnType<typeof store.getState>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,1 +1,23 @@
- 
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "jsx": "react-jsx",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/components/*": ["src/assets/js/components/*"],
+      "@/features/*": ["src/assets/js/features/*"],
+      "@/scss/*": ["src/assets/scss/*"],
+      "@/vendor/*": ["src/lib/vendor/*"],
+      "@/store": ["src/assets/js/store"],
+      "@/main": ["src/assets/js/main"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -13,15 +13,19 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.(js|jsx|mjs|ts|tsx)$/,
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
+      },
+      {
+        test: /\.(js|jsx|mjs)$/,
         exclude: /node_modules/,
         use: {
           loader: 'babel-loader',
           options: {
             presets: [
               '@babel/preset-env',
-              '@babel/preset-react',
-              '@babel/preset-typescript'
+              '@babel/preset-react'
             ]
           }
         }


### PR DESCRIPTION
### Description

We have partially migrated the React components to TypeScript. However, given the current Webpack configuration, the source code is only transpiled. There's no type checking done.

This pull request contains changes to the config so that type checking will be performed.

### Prerequisites

- [ ] Do a partial migration of the rest of the JavaScript code (Redux and helper code) to TypeScript.

### Checklist

- [ ] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have tested my changes on Google Chrome.
- [ ] I have tested my changes on Mozilla Firefox.
- [ ] I added a documentation for the changes I have made (when necessary).
