### PR TITLE
chore: fix `run_tests.sh`; refactor Bash scripts

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Validate that PLATFORM is either 'chrome' or 'firefox'
+validate_platform() {
+    local platform=$1
+    if [[ ! $platform =~ ^(chrome|firefox)$ ]]; then
+        echo "Invalid platform: $platform"
+        echo "Platform should be either chrome or firefox"
+        exit 1
+    fi
+}
+
+# Generate manifest.json from platform-specific template
+generate_manifest() {
+    local platform=$1
+    local version=${2:-0.0.0}
+
+    cat "src/manifest-$platform.json" \
+        | jq --arg version "$version" '.version = $version' \
+        > src/manifest.json
+}

--- a/bin/package_extension.sh
+++ b/bin/package_extension.sh
@@ -6,15 +6,10 @@ IFS=$'\n\t'
 VERSION=${VERSION:-0.0.0}
 PLATFORM=${PLATFORM:-chrome}
 
-if [[ ! $PLATFORM =~ ^(chrome|firefox)$ ]]; then
-    echo "Invalid platform: $PLATFORM"
-    echo "Platform should be either chrome or firefox"
-    exit 1
-fi
+source "$(dirname "$0")/common.sh"
 
-cat src/manifest-$PLATFORM.json \
-    | jq --arg version "$VERSION" '.version = $version' \
-    > src/manifest.json
+validate_platform "$PLATFORM"
+generate_manifest "$PLATFORM" "$VERSION"
 
 docker compose build
 docker run \

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -2,7 +2,16 @@
 
 set -euo pipefail
 
+VERSION=${VERSION:-0.0.0}
+PLATFORM=${PLATFORM:-chrome}
+
+source "$(dirname "$0")/common.sh"
+
+validate_platform "$PLATFORM"
+generate_manifest "$PLATFORM" "$VERSION"
+
 docker compose build
+
 docker run \
     --rm -ti \
     -v $(pwd):/app:delegated \

--- a/bin/start_development_mode.sh
+++ b/bin/start_development_mode.sh
@@ -6,15 +6,10 @@ IFS=$'\n\t'
 VERSION=${VERSION:-0.0.0}
 PLATFORM=${PLATFORM:-chrome}
 
-if [[ ! $PLATFORM =~ ^(chrome|firefox)$ ]]; then
-    echo "Invalid platform: $PLATFORM"
-    echo "Platform should be either chrome or firefox"
-    exit 1
-fi
+source "$(dirname "$0")/common.sh"
 
-cat src/manifest-$PLATFORM.json \
-    | jq --arg version "$VERSION" '.version = $version' \
-    > src/manifest.json
+validate_platform "$PLATFORM"
+generate_manifest "$PLATFORM" "$VERSION"
 
 docker compose down -v
 docker compose up --build


### PR DESCRIPTION
### Issues Fixed

* Fixes the issue where running `./bin/run_tests.sh` yields an error.

### Description

* `bin/run_tests.sh` should be updated so that a file called manifest.json can be generated.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have tested my changes on Google Chrome.
- [x] I have tested my changes on Mozilla Firefox.
- [x] I added a documentation for the changes I have made (when necessary).
