### PR TITLE
chore: rename Docker image name to `sbe_webpack`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,7 @@ jobs:
             --rm \
             -v $(pwd):/app:delegated \
             -v /app/node_modules \
-            sce_webpack:latest \
+            sbe_webpack:latest \
             /bin/bash -c "npx webpack --config webpack.dev.js && npm run test"
 
       - name: Build and Package the Extension
@@ -57,7 +57,7 @@ jobs:
             --rm \
             -v $(pwd)/artifacts:/app/artifacts:delegated \
             -v /app/artifacts/node_modules \
-            sce_webpack:latest \
+            sbe_webpack:latest \
             /bin/bash -c "npm run build && cp -r dist/ artifacts/"
 
       - name: Compress

--- a/bin/host_eslint.sh
+++ b/bin/host_eslint.sh
@@ -7,5 +7,5 @@ IFS=$'\n\t'
 docker run \
     --rm \
     -v $(pwd):$(pwd):delegated \
-    sce_webpack:latest \
+    sbe_webpack:latest \
     /app/node_modules/.bin/eslint $@

--- a/bin/package_extension.sh
+++ b/bin/package_extension.sh
@@ -16,7 +16,7 @@ docker run \
     --rm -ti \
     -v $(pwd):/app:delegated \
     -v /app/node_modules \
-    sce_webpack:latest \
+    sbe_webpack:latest \
     /bin/bash -c "npx webpack --config webpack.prod.js"
 
 (cd dist && zip -r ../screenly-$PLATFORM-extension-$VERSION.zip *)

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -16,6 +16,6 @@ docker run \
     --rm -ti \
     -v $(pwd):/app:delegated \
     -v /app/node_modules \
-    sce_webpack:latest \
+    sbe_webpack:latest \
     /bin/bash -c "npx webpack --config webpack.dev.js && npm test"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   webpack:
     build: .
     command: npx webpack --watch --config webpack.dev.js
-    image: sce_webpack:latest
+    image: sbe_webpack:latest
     volumes:
       - .:/app:delegated
       - /app/node_modules/  # exclude from volume mount; we want this inside the container


### PR DESCRIPTION
### Description

* The **_Screenly/Browser-Extension_** project was once called **_Screenly/Chrome-Extension_**.
* We need to rename the Docker images for consistency.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have tested my changes on Google Chrome.
- [x] I have tested my changes on Mozilla Firefox.
- [x] I added a documentation for the changes I have made (when necessary).
