### PR TITLE
fix: use query parameter to get asset data by id

### DIFF
--- a/src/assets/ts/main.ts
+++ b/src/assets/ts/main.ts
@@ -110,9 +110,10 @@ export function updateWebAsset(
 }
 
 export function getWebAsset(assetId: string | null, user: User) {
+  const queryParams = `id=eq.${encodeURIComponent(assetId || '')}`;
   return callApi(
     'GET',
-    `https://api.screenlyapp.com/api/v4/assets/${encodeURIComponent(assetId || '')}/`,
+    `https://api.screenlyapp.com/api/v4/assets/?${queryParams}`,
     null,
     user.token
   )


### PR DESCRIPTION
### Issues Fixed

* The function `getWebAsset` currently attempts to get an asset data by ID via a URL parameter.
* We should make use of a query parameter instead. 

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have tested my changes on Google Chrome.
- [x] I have tested my changes on Mozilla Firefox.
- [x] I added a documentation for the changes I have made (when necessary).
