### PR TITLE
fix: change state persistence logic to resolve unexpected data nesting

### DIFF
--- a/src/assets/ts/main.ts
+++ b/src/assets/ts/main.ts
@@ -165,7 +165,7 @@ export class State {
     return browser.storage.sync.get(['state'])
       .then((result: Record<string, BrowserStorageState>) => {
         // Initialize state properly from storage
-        let state = result.state || {};
+        const state = result.state || {};
 
         if (assetId) {
           state[url] = savedState;
@@ -185,8 +185,8 @@ export class State {
             // sync storage limit.
             return browser.storage.sync.remove('state').then(() => {
               if (assetId) {
-                state = { [url]: savedState };
-                return browser.storage.sync.set({ state });
+                const newState = { [url]: savedState };
+                return browser.storage.sync.set({ state: newState });
               } else {
                 return browser.storage.sync.set({ state: {} });
               }

--- a/src/assets/ts/main.ts
+++ b/src/assets/ts/main.ts
@@ -163,9 +163,9 @@ export class State {
     };
 
     return browser.storage.sync.get(['state'])
-      .then((result: Record<string, BrowserStorageState>) => {
+      .then((storageResult: Record<string, BrowserStorageState>) => {
         // Initialize state properly from storage
-        const state = result.state || {};
+        const state = storageResult.state || {};
 
         if (assetId) {
           state[url] = savedState;

--- a/src/assets/ts/main.ts
+++ b/src/assets/ts/main.ts
@@ -163,17 +163,18 @@ export class State {
     };
 
     return browser.storage.sync.get(['state'])
-      .then((state: BrowserStorageState) => {
-        state = state || {};
+      .then((result: Record<string, BrowserStorageState>) => {
+        // Initialize state properly from storage
+        let state = result.state || {};
 
         if (assetId) {
           state[url] = savedState;
-        } else
+        } else {
           delete state[url];
+        }
 
-        return browser.storage.sync.set({'state': state})
+        return browser.storage.sync.set({ state })
           .catch((error: Error) => {
-
             if (!error || !error.message || !error.message.includes('QUOTA_BYTES')) {
               // Unknown error. Ignore.
               throw error;
@@ -184,11 +185,11 @@ export class State {
             // sync storage limit.
             return browser.storage.sync.remove('state').then(() => {
               if (assetId) {
-                state = {};
-                state[url] = savedState;
-                return browser.storage.sync.set({'state': state});
-              } else
-                return browser.storage.sync.set({'state': {}});
+                state = { [url]: savedState };
+                return browser.storage.sync.set({ state });
+              } else {
+                return browser.storage.sync.set({ state: {} });
+              }
             });
           });
       });


### PR DESCRIPTION
### Issues Fixed

For instance, when I add **_Asset A_**, then **_Asset B_** via the extension/add-on, opening the popup for Asset A shows **_Add to Screenly_** instead of **_Update Asset_**.

Looking closer at the issue, there's an issue with how states are saved to browser storage. Data is unexpectedly nested.

### Description

Logic for saving state in browser storage was updated to prevent unwanted nesting. For instance:

```
{
  'state': {
    'state': { ... }
  }
}
```

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have tested my changes on Google Chrome.
- [x] I have tested my changes on Mozilla Firefox.
- [x] I added a documentation for the changes I have made (when necessary).

### Additional Information

Include any additional information that you think is necessary for this pull request,
including screenshots of the changes that you have made.
