### PR TITLE
fix: show screen for adding an asset if the asset was already removed

### DIFF
--- a/src/assets/ts/components/proposal.tsx
+++ b/src/assets/ts/components/proposal.tsx
@@ -121,11 +121,11 @@ export const Proposal: React.FC = () => {
           } else {
             setButtonState('update');
           }
-        } catch {
+        } catch (error) {
           setError((prev) => ({
             ...prev,
             show: true,
-            message: 'Failed to get asset details'
+            message: `Failed to get asset details: ${error}`
           }));
           setButtonState('add');
           setSaveAuthentication(false);

--- a/src/assets/ts/components/proposal.tsx
+++ b/src/assets/ts/components/proposal.tsx
@@ -114,9 +114,10 @@ export const Proposal: React.FC = () => {
 
         if (assets.length == 0) {
           setButtonState('add');
-          State.setSavedAssetState(url, null, false, false);
           setSaveAuthentication(false);
           setProposal(currentProposal);
+
+          State.setSavedAssetState(url, null, false, false);
         }
       } else {
         setButtonState('add');

--- a/src/assets/ts/components/proposal.tsx
+++ b/src/assets/ts/components/proposal.tsx
@@ -105,19 +105,33 @@ export const Proposal: React.FC = () => {
 
       if (currentProposal.state) {
         setSaveAuthentication(currentProposal.state.withCookies);
-        setButtonState('update');
 
-        const assets = await getWebAsset(
-          currentProposal.state.assetId,
-          currentProposal.user,
-        );
+        try {
+          const assets = await getWebAsset(
+            currentProposal.state.assetId,
+            currentProposal.user,
+          );
 
-        if (assets.length == 0) {
+          if (assets.length === 0) {
+            setButtonState('add');
+            setSaveAuthentication(false);
+            setProposal(currentProposal);
+
+            await State.setSavedAssetState(url, null, false, false);
+          } else {
+            setButtonState('update');
+          }
+        } catch {
+          setError((prev) => ({
+            ...prev,
+            show: true,
+            message: 'Failed to get asset details'
+          }));
           setButtonState('add');
           setSaveAuthentication(false);
           setProposal(currentProposal);
 
-          State.setSavedAssetState(url, null, false, false);
+          await State.setSavedAssetState(url, null, false, false);
         }
       } else {
         setButtonState('add');

--- a/src/assets/ts/components/proposal.tsx
+++ b/src/assets/ts/components/proposal.tsx
@@ -126,7 +126,7 @@ export const Proposal: React.FC = () => {
           await resetAssetState();
         }
 
-        function resetAssetState() {
+        async function resetAssetState() {
           setButtonState('add');
           setSaveAuthentication(false);
           setProposal(currentProposal);

--- a/src/assets/ts/components/proposal.tsx
+++ b/src/assets/ts/components/proposal.tsx
@@ -112,26 +112,25 @@ export const Proposal: React.FC = () => {
             currentProposal.user,
           );
 
-          if (assets.length === 0) {
-            setButtonState('add');
-            setSaveAuthentication(false);
-            setProposal(currentProposal);
+          setButtonState(assets.length === 0 ? 'add' : 'update');
 
-            await State.setSavedAssetState(url, null, false, false);
-          } else {
-            setButtonState('update');
+          if (assets.length === 0) {
+            await resetAssetState();
           }
         } catch (error) {
           setError((prev) => ({
             ...prev,
             show: true,
-            message: `Failed to get asset details: ${error.message}`
+            message: `Failed to get asset details: ${(error as Error).message}`
           }));
+          await resetAssetState();
+        }
+
+        function resetAssetState() {
           setButtonState('add');
           setSaveAuthentication(false);
           setProposal(currentProposal);
-
-          await State.setSavedAssetState(url, null, false, false);
+          return State.setSavedAssetState(url, null, false, false);
         }
       } else {
         setButtonState('add');

--- a/src/assets/ts/components/proposal.tsx
+++ b/src/assets/ts/components/proposal.tsx
@@ -125,7 +125,7 @@ export const Proposal: React.FC = () => {
           setError((prev) => ({
             ...prev,
             show: true,
-            message: `Failed to get asset details: ${error}`
+            message: `Failed to get asset details: ${error.message}`
           }));
           setButtonState('add');
           setSaveAuthentication(false);

--- a/src/assets/ts/components/proposal.tsx
+++ b/src/assets/ts/components/proposal.tsx
@@ -106,6 +106,18 @@ export const Proposal: React.FC = () => {
       if (currentProposal.state) {
         setSaveAuthentication(currentProposal.state.withCookies);
         setButtonState('update');
+
+        const assets = await getWebAsset(
+          currentProposal.state.assetId,
+          currentProposal.user,
+        );
+
+        if (assets.length == 0) {
+          setButtonState('add');
+          State.setSavedAssetState(url, null, false, false);
+          setSaveAuthentication(false);
+          setProposal(currentProposal);
+        }
       } else {
         setButtonState('add');
       }
@@ -233,6 +245,7 @@ export const Proposal: React.FC = () => {
     }
 
     const state = proposal.state;
+
     try {
       const result = !state
         ? await createWebAsset(

--- a/src/assets/ts/components/proposal.tsx
+++ b/src/assets/ts/components/proposal.tsx
@@ -103,6 +103,13 @@ export const Proposal: React.FC = () => {
 
       setProposal(currentProposal);
 
+      const resetAssetState = async () => {
+        setButtonState('add');
+        setSaveAuthentication(false);
+        setProposal(currentProposal);
+        return State.setSavedAssetState(url, null, false, false);
+      };
+
       if (currentProposal.state) {
         setSaveAuthentication(currentProposal.state.withCookies);
 
@@ -112,10 +119,10 @@ export const Proposal: React.FC = () => {
             currentProposal.user,
           );
 
-          setButtonState(assets.length === 0 ? 'add' : 'update');
-
           if (assets.length === 0) {
             await resetAssetState();
+          } else {
+            setButtonState('update');
           }
         } catch (error) {
           setError((prev) => ({
@@ -124,13 +131,6 @@ export const Proposal: React.FC = () => {
             message: `Failed to get asset details: ${(error as Error).message}`
           }));
           await resetAssetState();
-        }
-
-        async function resetAssetState() {
-          setButtonState('add');
-          setSaveAuthentication(false);
-          setProposal(currentProposal);
-          return State.setSavedAssetState(url, null, false, false);
         }
       } else {
         setButtonState('add');


### PR DESCRIPTION
### Issues Fixed

The popup shows interface for updating a web asset even if that asset's already removed from Screenly via the web interface.

### Changes

* If the asset was already deleted, the popup will show the interface for adding a new asset instead.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have tested my changes on Google Chrome.
- [x] I have tested my changes on Mozilla Firefox.
- [x] I added a documentation for the changes I have made (when necessary).
