### PR TITLE
fix: remove saved asset data from storage instead of nullifying it

### DIFF
--- a/src/assets/ts/components/proposal.tsx
+++ b/src/assets/ts/components/proposal.tsx
@@ -107,7 +107,7 @@ export const Proposal: React.FC = () => {
         setButtonState('add');
         setSaveAuthentication(false);
         setProposal(currentProposal);
-        return State.setSavedAssetState(url, null, false, false);
+        await State.removeSavedAssetState(url);
       };
 
       if (currentProposal.state) {

--- a/src/assets/ts/main.ts
+++ b/src/assets/ts/main.ts
@@ -209,4 +209,15 @@ export class State {
         return v;
       });
   }
+
+  static removeSavedAssetState(url: string) {
+    url = State.simplifyUrl(url);
+
+    return browser.storage.sync.get(['state'])
+      .then((result: { state?: BrowserStorageState }) => {
+        const state = result.state || {};
+        delete state[url];
+        return browser.storage.sync.set({ state });
+      });
+  }
 }


### PR DESCRIPTION
### Issues Fixed

In #101, if an asset was previously added via the browser extension and was then deleted via the Screenly web console, the key-value entry for that asset was never deleted&mdash;the values of most attributes are just set to `null`, `undefined`, `false`, or similar.

### Description

A new static method named `State.removeSavedAssetFromState(string)` was created to fully remove the key-value entry.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have tested my changes on Google Chrome.
- [x] I have tested my changes on Mozilla Firefox.
- [x] I added a documentation for the changes I have made (when necessary).
