### PR TITLE
chore: raise ESLint errors for `no-unused-vars` and `no-undef`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -64,8 +64,7 @@ export default [
     rules: {
       'react/prop-types': 'off',
       '@typescript-eslint/explicit-function-return-type': 'off',
-      '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
-      'no-unused-vars': 'error',
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
       'no-undef': 'error',
     },
   }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -51,6 +51,7 @@ export default [
         Atomics: 'readonly',
         SharedArrayBuffer: 'readonly',
         React: 'readonly',
+        EventListener: 'readonly',
       },
       ecmaVersion: 'latest',
       sourceType: 'module',
@@ -65,6 +66,8 @@ export default [
       'react/prop-types': 'off',
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+      'no-unused-vars': 'error',
+      'no-undef': 'error',
     },
   }
 ];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -51,7 +51,6 @@ export default [
         Atomics: 'readonly',
         SharedArrayBuffer: 'readonly',
         React: 'readonly',
-        EventListener: 'readonly',
       },
       ecmaVersion: 'latest',
       sourceType: 'module',

--- a/src/assets/ts/main.ts
+++ b/src/assets/ts/main.ts
@@ -1,4 +1,5 @@
 /// <reference types="chrome"/>
+/* global browser, chrome */
 'use strict';
 
 import normalizeUrl from 'normalize-url';
@@ -95,7 +96,7 @@ export function updateWebAsset(
   url: string,
   title: string,
   headers: object | null,
-  disableVerification: boolean, // eslint-disable-line @typescript-eslint/no-unused-vars
+  disableVerification: boolean,
 ) {
   const queryParams = `id=eq.${encodeURIComponent(assetId || '')}`;
   return callApi(
@@ -104,6 +105,7 @@ export function updateWebAsset(
     {
       'title': title,
       'headers': headers,
+      'disable_verification': disableVerification,
     },
     user.token
   );

--- a/src/assets/ts/main.ts
+++ b/src/assets/ts/main.ts
@@ -103,6 +103,7 @@ export function updateWebAsset(
     'PATCH',
     `https://api.screenlyapp.com/api/v4/assets/?${queryParams}`,
     {
+      // API expects snake_case, so we transform from camelCase
       'title': title,
       'headers': headers,
       'disable_verification': disableVerification,

--- a/src/assets/ts/popup.tsx
+++ b/src/assets/ts/popup.tsx
@@ -1,3 +1,4 @@
+/* global EventListener */
 import ReactDOM from 'react-dom/client';
 import {
   useEffect,


### PR DESCRIPTION
### Issues Fixed

* Violating `no-unused-vars` would only raise a warning.
* ESLint will either raise nothing or only raise a warning when `no-undef` is violated.

### Description

* Updated ESLint config so that `no-unused-vars` and `no-undef` will be treated as errors.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have tested my changes on Google Chrome.
- [x] I have tested my changes on Mozilla Firefox.
- [x] I added a documentation for the changes I have made (when necessary).