### PR TITLE
fix: specify team domain when opening asset dashboard link

### DIFF
--- a/src/assets/ts/components/proposal.tsx
+++ b/src/assets/ts/components/proposal.tsx
@@ -13,6 +13,7 @@ import {
   getAssetDashboardLink,
   getUser,
   getWebAsset,
+  getTeamInfo,
   createWebAsset,
   updateWebAsset,
   State,
@@ -291,8 +292,11 @@ export const Proposal: React.FC = () => {
 
       setButtonState(state ? 'update' : 'add');
 
+      const teamInfo = await getTeamInfo(proposal.user, result[0].team_id);
+      const teamDomain = teamInfo[0].domain;
+
       const event = new CustomEvent('set-asset-dashboard-link', {
-        detail: getAssetDashboardLink(result[0].id)
+        detail: getAssetDashboardLink(result[0].id, teamDomain)
       });
       document.dispatchEvent(event);
 

--- a/src/assets/ts/main.ts
+++ b/src/assets/ts/main.ts
@@ -122,8 +122,18 @@ export function getWebAsset(assetId: string | null, user: User) {
   )
 }
 
-export function getAssetDashboardLink(assetId: string) {
-  return `https://login.screenlyapp.com/login?next=/manage/assets/${assetId}`;
+export function getTeamInfo(user: User, teamId: string) {
+  const queryParams = `id=eq.${encodeURIComponent(teamId || '')}`;
+  return callApi(
+    'GET',
+    `https://api.screenlyapp.com/api/v4.1/teams/?${queryParams}`,
+    null,
+    user.token
+  )
+}
+
+export function getAssetDashboardLink(assetId: string, teamDomain: string) {
+  return `https://${teamDomain}.screenlyapp.com/manage/assets/${assetId}`;
 }
 
 


### PR DESCRIPTION
### Issues Fixed

* Fixes #104

### Description

Update `getAssetDashboardLink` to open a Screenly URL with variable domain name depending on the argument passed

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have tested my changes on Google Chrome.
- [x] I have tested my changes on Mozilla Firefox.
- [x] I added a documentation for the changes I have made (when necessary).
