### PR TITLE
chore(ci): move the unit test step to a new workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,15 +41,6 @@ jobs:
         run: |
           docker compose build
 
-      - name: Run Unit Tests
-        run: |
-          docker run \
-            --rm \
-            -v $(pwd):/app:delegated \
-            -v /app/node_modules \
-            sbe_webpack:latest \
-            /bin/bash -c "npx webpack --config webpack.dev.js && npm run test"
-
       - name: Build and Package the Extension
         run: |
           mkdir artifacts

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,33 @@
+---
+name: Run Unit Tests
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+    tags:
+      - v*.*
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    name: Run Unit Tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build Docker images
+        run: |
+          docker compose build
+
+      - name: Run Unit Tests
+        run: |
+          docker run \
+            --rm \
+            -v $(pwd):/app:delegated \
+            -v /app/node_modules \
+            sbe_webpack:latest \
+            /bin/bash -c "npx webpack --config webpack.dev.js && npm run test"


### PR DESCRIPTION
### Description

Unit tests are currently run before build artifacts are generated. I decided to move the unit test step to a new workflow to prevent blocking.

This would be helpful to other contributors. For instance, if the unit test fails even if the packaged extension is running, they will still be able to test the generated artifacts.

### Checklist

- [ ] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have tested my changes on Google Chrome.
- [ ] I have tested my changes on Mozilla Firefox.
- [ ] I added a documentation for the changes I have made (when necessary).
