### PR TITLE
fix: create new components for asset save failures; rename files

### DIFF
--- a/src/assets/ts/components/asset-save-failure.tsx
+++ b/src/assets/ts/components/asset-save-failure.tsx
@@ -1,17 +1,18 @@
-import { CheckMark } from './check-mark';
+import { XMark } from '@/components/x-mark';
 
-export const SignInSuccess: React.FC = () => {
+export const AssetSaveFailure: React.FC = () => {
   return (
-    <div className="page" id="success-page">
+    <div className="page" id="failure-page">
       <div className="d-flex flex-column">
         <section className="align-items-center d-flex flex-grow-1 justify-content-center">
           <div>
             <div className="d-flex justify-content-center align-items-center">
-              <CheckMark />
+              <XMark />
             </div>
-            <h3 className="text-center">Sign in successful!</h3>
+            <h3 className="text-center">Failed to save web page</h3>
             <p className="text-muted">
-              You can now add and update web assets to your Screenly account.
+              The web page you are trying to save might not be supported or
+              there was an error saving the web page. Please try again.
             </p>
           </div>
         </section>

--- a/src/assets/ts/components/asset-save-success.tsx
+++ b/src/assets/ts/components/asset-save-success.tsx
@@ -2,7 +2,7 @@ interface SuccessProps {
   assetDashboardLink: string;
 }
 
-import { Checkmark } from './Checkmark';
+import { CheckMark } from '@/components/check-mark';
 
 export const AssetSaveSuccess: React.FC<SuccessProps> = ({
   assetDashboardLink,
@@ -17,7 +17,7 @@ export const AssetSaveSuccess: React.FC<SuccessProps> = ({
         <section className="align-items-center d-flex flex-grow-1 justify-content-center">
           <div>
             <div className="d-flex justify-content-center align-items-center">
-              <Checkmark />
+              <CheckMark />
             </div>
             <h3 className="text-center">Web page saved!</h3>
             <p className="text-muted">

--- a/src/assets/ts/components/check-mark.tsx
+++ b/src/assets/ts/components/check-mark.tsx
@@ -1,8 +1,8 @@
 import 'sweetalert2/src/sweetalert2.scss';
 
-export const Checkmark: React.FC = () => {
+export const CheckMark: React.FC = () => {
   return (
-    <div className="swal2-icon swal2-success swal2-icon-show">
+    <div className="swal2-icon swal2-success swal2-icon-show mb-3">
       <div className="swal2-success-circular-line-left"></div>
       <span className="swal2-success-line-tip"></span>
       <span className="swal2-success-line-long"></span>

--- a/src/assets/ts/components/x-mark.tsx
+++ b/src/assets/ts/components/x-mark.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import 'sweetalert2/src/sweetalert2.scss';
+
+export const XMark: React.FC = () => {
+  return (
+    <div className="swal2-icon swal2-error swal2-icon-show mb-3">
+      <span className="swal2-x-mark-sign">
+        <span className="swal2-x-mark-line-left"></span>
+        <span className="swal2-x-mark-line-right"></span>
+      </span>
+    </div>
+  );
+};

--- a/src/assets/ts/features/popup-slice.ts
+++ b/src/assets/ts/features/popup-slice.ts
@@ -23,11 +23,18 @@ const popupSlice = createSlice({
     showSignInSuccess: false,
     assetDashboardLink: '',
     showSettings: false,
+    showAssetSaveFailure: false,
   },
   reducers: {
     notifyAssetSaveSuccess: (state) => {
       state.showSuccess = true;
       state.showProposal = false;
+      state.showAssetSaveFailure = false;
+    },
+    notifyAssetSaveFailure: (state) => {
+      state.showSuccess = false;
+      state.showProposal = false;
+      state.showAssetSaveFailure = true;
     },
     notifySignInSuccess: (state) => {
       state.showSignIn = false;
@@ -53,6 +60,10 @@ const popupSlice = createSlice({
   },
 });
 
-export const { notifyAssetSaveSuccess, notifySignInSuccess, openSettings } =
-  popupSlice.actions;
+export const {
+  notifyAssetSaveSuccess,
+  notifyAssetSaveFailure,
+  notifySignInSuccess,
+  openSettings,
+} = popupSlice.actions;
 export default popupSlice.reducer;

--- a/src/assets/ts/popup.tsx
+++ b/src/assets/ts/popup.tsx
@@ -8,6 +8,7 @@ import '@/scss/style.scss';
 
 import { SignInForm } from '@/components/sign-in';
 import { AssetSaveSuccess } from '@/components/asset-save-success';
+import { AssetSaveFailure } from '@/components/asset-save-failure';
 import { Proposal } from '@/components/proposal';
 import { SignInSuccess } from '@/components/sign-in-success';
 import { Settings } from '@/components/settings';
@@ -29,6 +30,7 @@ const PopupPage: React.FC = () => {
     showSuccess,
     showSignInSuccess,
     showSettings,
+    showAssetSaveFailure,
   } = useSelector((state: RootState) => state.popup);
 
   const [assetDashboardLink, setAssetDashboardLink] = useState<string>('');
@@ -62,6 +64,7 @@ const PopupPage: React.FC = () => {
       )}
       {showSignInSuccess && <SignInSuccess />}
       {showSettings && <Settings />}
+      {showAssetSaveFailure && <AssetSaveFailure />}
     </>
   );
 };


### PR DESCRIPTION
### Issues Fixed

* Fixes #104

### Description

* Creates new components for x-mark and asset save failure message.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have tested my changes on Google Chrome.
- [x] I have tested my changes on Mozilla Firefox.
- [x] I added a documentation for the changes I have made (when necessary).

### Screenshots

#### Before Fixes

![before](https://github.com/user-attachments/assets/09357887-21ed-433f-817a-cc356668ba88)

#### After Fixes

![after](https://github.com/user-attachments/assets/8eae9dbf-2cbd-44ab-ad79-f7e1c18ea9de)

#### Timeout/Failure Case

> [!NOTE]
> As the failure situation is harder to replicate, I've temporarily tweaked poll rate and interval to have the failure message appear.

![image](https://github.com/user-attachments/assets/c8554788-4b17-412c-80ac-d2d7ad7662f6)