### PR TITLE
chore: rename `webpack` service to `browser-extension`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ $ PLATFORM=<PLATFORM> \
 
 Now load the content of the `dist/` folder as an unpacked extension in Chrome. As you make changes to the code, the extension is automatically rebuilt.
 
+### Getting Inside the Docker Container
+
+```bash
+$ docker compose exec browser-extension bash
+```
+
 ### Distribute
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
-  webpack:
+  browser-extension:
     build: .
     command: npx webpack --watch --config webpack.dev.js
     image: sbe_webpack:latest


### PR DESCRIPTION
### Description

Renames the `webpack` service to `browser-extension`.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have tested my changes on Google Chrome.
- [x] I have tested my changes on Mozilla Firefox.
- [x] I added a documentation for the changes I have made (when necessary).
