### PR TITLE
chore: move type and interface declarations to a separate file

### DIFF
--- a/src/assets/ts/components/proposal.tsx
+++ b/src/assets/ts/components/proposal.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import type { User } from '@/main';
+import type { User } from '@/types/core';
 
 import { PopupSpinner } from '@/components/popup-spinner';
 import { SaveAuthWarning } from '@/components/save-auth-warning';
@@ -17,48 +17,22 @@ import {
   createWebAsset,
   updateWebAsset,
   State,
-  SavedAssetState,
 } from '@/main';
 import {
   notifyAssetSaveSuccess,
   notifyAssetSaveFailure,
   openSettings,
 } from '@/features/popup-slice';
+import {
+  ErrorState,
+  ButtonState,
+  ApiError,
+  Cookie,
+  ProposalState,
+} from '@/types/core';
 
 const MAX_ASSET_STATUS_POLL_COUNT = 30;
 const ASSET_STATUS_POLL_INTERVAL_MS = 1000;
-
-interface ErrorState {
-  show: boolean;
-  message: string;
-}
-
-interface ProposalState {
-  user: User;
-  title: string;
-  url: string;
-  cookieJar: Cookie[];
-  state?: SavedAssetState;
-}
-
-interface Cookie {
-  domain: string;
-  name: string;
-  value: string;
-  hostOnly?: boolean;
-}
-
-type ButtonState = 'add' | 'update' | 'loading';
-
-interface AssetError {
-  type?: string[];
-}
-
-interface ApiError {
-  status?: number;
-  statusCode?: number;
-  json(): Promise<AssetError>;
-}
 
 export const Proposal: React.FC = () => {
   const dispatch = useDispatch();

--- a/src/assets/ts/main.ts
+++ b/src/assets/ts/main.ts
@@ -9,28 +9,16 @@ import {
   UserResponse,
   TeamResponse,
 } from '@/types/screenly-api';
-
-interface RequestInit {
-  method: string;
-  headers: Record<string, string>;
-  body?: string;
-}
-
-export interface User {
-  token?: string;
-}
+import {
+  User,
+  RequestInit,
+  SavedAssetState,
+  BrowserStorageState,
+} from '@/types/core';
 
 declare global {
   const browser: typeof chrome;
 }
-
-export interface SavedAssetState {
-  assetId: string | null;
-  withCookies: boolean;
-  withBypass: boolean;
-}
-
-export type BrowserStorageState = Record<string, SavedAssetState>;
 
 export function callApi(
   method: string,

--- a/src/assets/ts/popup.tsx
+++ b/src/assets/ts/popup.tsx
@@ -16,10 +16,7 @@ import { Settings } from '@/components/settings';
 import { store } from '@/store';
 import { signIn } from '@/features/popup-slice';
 import { RootState, AppDispatch } from '@/store';
-
-interface CustomEvent extends Event {
-  detail: string;
-}
+import { CustomEvent } from '@/types/core';
 
 const PopupPage: React.FC = () => {
   const dispatch = useDispatch<AppDispatch>();

--- a/src/assets/ts/types/core.ts
+++ b/src/assets/ts/types/core.ts
@@ -1,0 +1,90 @@
+/**
+ * Core types and interfaces for the Browser Extension
+ */
+
+/**
+ * User interface representing the authenticated user
+ */
+export interface User {
+  token?: string;
+}
+
+/**
+ * Request initialization interface for API calls
+ */
+export interface RequestInit {
+  method: string;
+  headers: Record<string, string>;
+  body?: string;
+}
+
+/**
+ * Saved asset state interface for browser storage
+ */
+export interface SavedAssetState {
+  assetId: string | null;
+  withCookies: boolean;
+  withBypass: boolean;
+}
+
+/**
+ * Browser storage state type
+ */
+export type BrowserStorageState = Record<string, SavedAssetState>;
+
+/**
+ * Custom event interface for asset dashboard link
+ */
+export interface CustomEvent extends Event {
+  detail: string;
+}
+
+/**
+ * Error state interface for form validation
+ */
+export interface ErrorState {
+  show: boolean;
+  message: string;
+}
+
+/**
+ * Button state type for form submission
+ */
+export type ButtonState = 'add' | 'update' | 'loading';
+
+/**
+ * Asset error interface for API error handling
+ */
+export interface AssetError {
+  type?: string[];
+}
+
+/**
+ * API error interface for error handling
+ */
+export interface ApiError {
+  status?: number;
+  statusCode?: number;
+  json(): Promise<AssetError>;
+}
+
+/**
+ * Cookie interface for browser cookies
+ */
+export interface Cookie {
+  domain: string;
+  name: string;
+  value: string;
+  hostOnly?: boolean;
+}
+
+/**
+ * Proposal state interface for asset proposals
+ */
+export interface ProposalState {
+  user: User;
+  title: string;
+  url: string;
+  cookieJar: Cookie[];
+  state?: SavedAssetState;
+}

--- a/src/test/spec/test-main.ts
+++ b/src/test/spec/test-main.ts
@@ -4,7 +4,8 @@
 /* global browser */
 declare const global: typeof globalThis;
 
-import { State, SavedAssetState, BrowserStorageState } from '@/main';
+import { State } from '@/main';
+import type { SavedAssetState, BrowserStorageState } from '@/types/core';
 
 type BrowserMock = {
   storage: {


### PR DESCRIPTION
### Description

Moves [type and interface declarations](https://www.typescriptlang.org/docs/handbook/2/objects.html) to a separate file.

### Checklist

- [ ] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have tested my changes on Google Chrome.
- [ ] I have tested my changes on Mozilla Firefox.
- [ ] I added a documentation for the changes I have made (when necessary).
