### PR TITLE
feat: add an info/wait message if status polling takes more than a couple seconds

### DIFF
--- a/src/assets/scss/style.scss
+++ b/src/assets/scss/style.scss
@@ -78,7 +78,8 @@ body.popup {
   hyphens: auto;
 }
 
-.TokenHelpText {
+.TokenHelpText,
+#polling-message {
   &.alert {
     background-color: #f9f9f9;
   }


### PR DESCRIPTION
### Issues Fixed

- When adding assets, the app polls for the asset's status before confirming whether it's successful or not. The polling might take a while.

### Description

- Adds an info message stating that it might take a while for the process to finish

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have tested my changes on Google Chrome.
- [x] I have tested my changes on Mozilla Firefox.
- [x] I added a documentation for the changes I have made (when necessary).

### Screenshots

![image](https://github.com/user-attachments/assets/ba382afc-7346-4ece-bf72-e34a88deee1c)

