### PR TITLE
chore: refactor URL params to use `URLSearchParams` instead

### DIFF
--- a/src/assets/ts/main.ts
+++ b/src/assets/ts/main.ts
@@ -94,10 +94,11 @@ export function updateWebAsset(
   headers: object | null,
   disableVerification: boolean,
 ): Promise<AssetResponse[]> {
-  const queryParams = `id=eq.${encodeURIComponent(assetId || '')}`;
+  const params = new URLSearchParams({ id: `eq.${assetId || ''}` });
+
   return callApi(
     'PATCH',
-    `https://api.screenlyapp.com/api/v4/assets/?${queryParams}`,
+    `https://api.screenlyapp.com/api/v4/assets/?${params.toString()}`,
     {
       // API expects snake_case, so we transform from camelCase
       title: title,
@@ -114,10 +115,11 @@ export function getWebAsset(
   assetId: string | null,
   user: User,
 ): Promise<AssetResponse[]> {
-  const queryParams = `id=eq.${encodeURIComponent(assetId || '')}`;
+  const params = new URLSearchParams({ id: `eq.${assetId || ''}` });
+
   return callApi(
     'GET',
-    `https://api.screenlyapp.com/api/v4/assets/?${queryParams}`,
+    `https://api.screenlyapp.com/api/v4/assets/?${params.toString()}`,
     null,
     user.token,
   ).then((response: ApiResponseData[]) => {
@@ -129,10 +131,11 @@ export function getTeamInfo(
   user: User,
   teamId: string,
 ): Promise<TeamResponse[]> {
-  const queryParams = `id=eq.${encodeURIComponent(teamId || '')}`;
+  const params = new URLSearchParams({ id: `eq.${teamId || ''}` });
+
   return callApi(
     'GET',
-    `https://api.screenlyapp.com/api/v4.1/teams/?${queryParams}`,
+    `https://api.screenlyapp.com/api/v4.1/teams/?${params.toString()}`,
     null,
     user.token,
   ).then((response: ApiResponseData[]) => {


### PR DESCRIPTION
### Description

Replaced occurrences of raw query parameter strings with [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams).

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have tested my changes on Google Chrome.
- [x] I have tested my changes on Mozilla Firefox.
- [x] I added a documentation for the changes I have made (when necessary).