### PR TITLE
fix: encode source URL during API lookup

### DIFF
--- a/src/assets/ts/features/asset/thunks/update-proposal.ts
+++ b/src/assets/ts/features/asset/thunks/update-proposal.ts
@@ -35,7 +35,7 @@ export const updateProposal = createAsyncThunk<
     const queryParams = [
       'and=(type.not.eq.edge-app-file,type.not.eq.edge-app)',
       'or=(status.eq.downloading,status.eq.processing,status.eq.finished)',
-      `source_url=eq.${url}`,
+      `source_url=eq.${encodeURIComponent(url)}`,
     ].join('&');
     const result = await callApi(
       'GET',


### PR DESCRIPTION
### Issues Fixed

I'm getting the following on some web pages:

![image](https://github.com/user-attachments/assets/7d692981-f483-4551-9573-5b42213f420d)

I looked closely and found out that there was a PostgREST query error, giving a status code of 400.


### Description

Encodes source URL that will be looked up via the Screenly REST API

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have tested my changes on Google Chrome.
- [x] I have tested my changes on Mozilla Firefox.
- [x] I added a documentation for the changes I have made (when necessary).
