### PR TITLE
fix: update minimum Firefox version in manifest file

### DIFF
--- a/src/manifest-firefox.json
+++ b/src/manifest-firefox.json
@@ -29,7 +29,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "addon@screenly.io",
-      "strict_min_version": "60.0"
+      "strict_min_version": "102.0"
     }
   }
 }


### PR DESCRIPTION
### Issues Fixed

The following warnings show up during the upload of a new release:
- **Warning:** "strict_min_version" requires Firefox 60, which was released before 109 introduced support for "action".
- **Warning:** "strict_min_version" requires Firefox 60, which was released before 109 introduced support for "action.default_icon".
- **Warning:** "strict_min_version" requires Firefox 60, which was released before 109 introduced support for "action.default_popup".
- **Warning:** "strict_min_version" requires Firefox 60, which was released before 109 introduced support for "action.default_title".
- **Warning:** "strict_min_version" requires Firefox 60, which was released before 109 introduced support for "host_permissions".
- **Warning:** "strict_min_version" requires Firefox 60, which was released before 102 introduced support for "permissions:scripting".

### Description

- Updated the `manifest.json` template for Firefox add-ons

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have tested my changes on Google Chrome.
- [x] I have tested my changes on Mozilla Firefox.
- [x] I added a documentation for the changes I have made (when necessary).
