### PR TITLE
chore: rename Docker image name

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,7 +48,7 @@ jobs:
             --rm \
             -v $(pwd)/artifacts:/app/artifacts:delegated \
             -v /app/artifacts/node_modules \
-            sbe_webpack:latest \
+            screenly-browser-extension:latest \
             /bin/bash -c "npm run build && cp -r dist/ artifacts/"
 
       - name: Compress

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,5 +44,5 @@ jobs:
             --rm \
             -v $(pwd):/app:delegated \
             -v /app/node_modules \
-            sbe_webpack:latest \
+            screenly-browser-extension:latest \
             /bin/bash -c "npx webpack --config webpack.dev.js && npm run test"

--- a/bin/package_extension.sh
+++ b/bin/package_extension.sh
@@ -16,7 +16,7 @@ docker run \
     --rm -ti \
     -v $(pwd):/app:delegated \
     -v /app/node_modules \
-    sbe_webpack:latest \
+    screenly-browser-extension:latest \
     /bin/bash -c "npx webpack --config webpack.prod.js"
 
 (cd dist && zip -r ../screenly-$PLATFORM-extension-$VERSION.zip *)

--- a/bin/run_eslint.sh
+++ b/bin/run_eslint.sh
@@ -8,5 +8,5 @@ docker run \
     --rm \
     -v $(pwd):/app:delegated \
     -v /app/node_modules \
-    sbe_webpack:latest \
+    screenly-browser-extension:latest \
     npx eslint "$@"

--- a/bin/run_formatter.sh
+++ b/bin/run_formatter.sh
@@ -15,5 +15,5 @@ docker run \
     --rm \
     -v $(pwd):/app:delegated \
     -v /app/node_modules \
-    sbe_webpack:latest \
+    screenly-browser-extension:latest \
     npx prettier src/ --${MODE}

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -16,6 +16,6 @@ docker run \
     --rm -ti \
     -v $(pwd):/app:delegated \
     -v /app/node_modules \
-    sbe_webpack:latest \
+    screenly-browser-extension:latest \
     /bin/bash -c "npm test"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   browser-extension:
     build: .
     command: npx webpack --watch --config webpack.dev.js
-    image: sbe_webpack:latest
+    image: screenly-browser-extension:latest
     volumes:
       - .:/app:delegated
       - /app/node_modules/  # exclude from volume mount; we want this inside the container


### PR DESCRIPTION
### Description

- Renamed Docker image name from `sbe_webpack` to `screenly-browser-extension`
- In situations where a switch to another bundler (e.g. from WebPack to Vite, Rollup, Parcel, etc.) is needed, the current name `sbe_webpack` will not be relevant anymore.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have tested my changes on Google Chrome.
- [x] I have tested my changes on Mozilla Firefox.
- [x] I added a documentation for the changes I have made (when necessary).