### PR TITLE
refactor: move `PopupPage` component to a new file

### DIFF
--- a/src/assets/ts/components/popup-page.tsx
+++ b/src/assets/ts/components/popup-page.tsx
@@ -1,7 +1,6 @@
 /* global EventListener */
-import ReactDOM from 'react-dom/client';
 import { useEffect, useState } from 'react';
-import { Provider, useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import 'bootstrap-icons/font/bootstrap-icons.scss';
 
 import '@/scss/style.scss';
@@ -13,12 +12,11 @@ import { Proposal } from '@/components/proposal';
 import { SignInSuccess } from '@/components/sign-in-success';
 import { Settings } from '@/components/settings';
 
-import { store } from '@/store';
 import { signIn } from '@/features/popup-slice';
 import { RootState, AppDispatch } from '@/store';
 import { CustomEvent } from '@/types/core';
 
-const PopupPage: React.FC = () => {
+export const PopupPage: React.FC = () => {
   const dispatch = useDispatch<AppDispatch>();
 
   const {
@@ -65,13 +63,3 @@ const PopupPage: React.FC = () => {
     </>
   );
 };
-
-const container = document.getElementById('app');
-if (!container) throw new Error('Failed to find the app element');
-
-const root = ReactDOM.createRoot(container);
-root.render(
-  <Provider store={store}>
-    <PopupPage />
-  </Provider>,
-);

--- a/src/assets/ts/index.tsx
+++ b/src/assets/ts/index.tsx
@@ -1,0 +1,18 @@
+import ReactDOM from 'react-dom/client';
+import { Provider } from 'react-redux';
+
+import 'bootstrap-icons/font/bootstrap-icons.scss';
+import '@/scss/style.scss';
+
+import { PopupPage } from '@/components/popup-page';
+import { store } from '@/store';
+
+const container = document.getElementById('app');
+if (!container) throw new Error('Failed to find the app element');
+
+const root = ReactDOM.createRoot(container);
+root.render(
+  <Provider store={store}>
+    <PopupPage />
+  </Provider>,
+);

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -7,7 +7,7 @@ const webpack = require('webpack');
 
 module.exports = {
   entry: {
-    'popup': './src/assets/ts/popup.tsx',
+    'popup': './src/assets/ts/index.tsx',
   },
 
   module: {


### PR DESCRIPTION
### Description

- Moved the `PopupPage` component to a new file called `popup-page.tsx`
- Renamed the entrypoint file `popup.tsx` to `index.tsx`

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have tested my changes on Google Chrome.
- [x] I have tested my changes on Mozilla Firefox.
- [x] I added a documentation for the changes I have made (when necessary).