### PR TITLE
chore(ci): automatically generate release notes when creating a new release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,6 +80,7 @@ jobs:
         uses: ncipollo/release-action@v1.11.2
         with:
           allowUpdates: true
+          generateReleaseNotes: true
           prerelease: true
           artifacts: "screenly-${{ matrix.platform }}-extension-${{ github.ref_name }}.zip"
 


### PR DESCRIPTION
### Issues Fixed

Manually writing release notes from scratch has started to become cumbersome.

### Description

This pull request modifies the release workflow so that [release notes will be automatically generated](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) when a new release is created.

### Checklist

- [ ] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have tested my changes on Google Chrome.
- [ ] I have tested my changes on Mozilla Firefox.
- [ ] I added a documentation for the changes I have made (when necessary).
