### PR TITLE
fix: rewrite Origin header to bypass CORS restriction on Screenly API

### DIFF
--- a/src/assets/rules.json
+++ b/src/assets/rules.json
@@ -13,7 +13,7 @@
       ]
     },
     "condition": {
-      "urlFilter": "https://api.screenlyapp.com/*",
+      "urlFilter": "https://api.screenlyapp.com/api/*",
       "resourceTypes": ["xmlhttprequest"]
     }
   }

--- a/src/assets/rules.json
+++ b/src/assets/rules.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": 1,
+    "priority": 1,
+    "action": {
+      "type": "modifyHeaders",
+      "requestHeaders": [
+        {
+          "header": "Origin",
+          "operation": "set",
+          "value": "https://app.screenlyapp.com"
+        }
+      ]
+    },
+    "condition": {
+      "urlFilter": "https://api.screenlyapp.com/*",
+      "resourceTypes": ["xmlhttprequest"]
+    }
+  }
+]

--- a/src/manifest-chrome.json
+++ b/src/manifest-chrome.json
@@ -12,8 +12,18 @@
     "activeTab",
     "storage",
     "scripting",
-    "cookies"
+    "cookies",
+    "declarativeNetRequest"
   ],
+  "declarative_net_request": {
+    "rule_resources": [
+      {
+        "id": "screenly_api_rules",
+        "enabled": true,
+        "path": "assets/rules.json"
+      }
+    ]
+  },
   "host_permissions": [
     "http://*/*",
     "https://*/*"

--- a/src/manifest-firefox.json
+++ b/src/manifest-firefox.json
@@ -12,8 +12,18 @@
     "activeTab",
     "storage",
     "scripting",
-    "cookies"
+    "cookies",
+    "declarativeNetRequest"
   ],
+  "declarative_net_request": {
+    "rule_resources": [
+      {
+        "id": "screenly_api_rules",
+        "enabled": true,
+        "path": "assets/rules.json"
+      }
+    ]
+  },
   "host_permissions": [
     "http://*/*",
     "https://*/*"

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -69,6 +69,14 @@ module.exports = {
         },
       ],
     }),
+    new CopyWebpackPlugin({
+      patterns: [
+        {
+          from: "src/assets/rules.json",
+          to: "assets/rules.json",
+        },
+      ],
+    }),
     new HtmlWebpackPlugin({
       filename: 'popup.html',
       template: './src/popup.html',


### PR DESCRIPTION
## Summary

- The Screenly API rejects requests from `chrome-extension://` and `moz-extension://` origins with a 403, blocking all API calls from the extension
- Uses `declarativeNetRequest` to rewrite the `Origin` header to `https://app.screenlyapp.com` on all requests to `api.screenlyapp.com`
- Adds `rules.json` static ruleset and wires it into both browser manifests and the webpack build

## Notes

- This is a **temporary fix** pending a backend CORS allowlist update to include browser extension origins

## Test plan

- [x] Rebuild extension (`generate_manifest chrome && npx webpack --config webpack.prod.js`)
- [x] Load unpacked extension in Chrome, sign in with a valid token; should succeed
- [x] Navigate to a web page and click "Add to Screenly"; asset should be created successfully