### PR TITLE
fix: prevent cookie header value corruption when saving authenticated pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "bootstrap": "^5.3.8",
         "bootstrap-icons": "^1.13.1",
-        "cookie": "^1.0.2",
         "normalize-url": "^8.1.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -5221,15 +5220,6 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cookie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
-      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/copy-webpack-plugin": {
       "version": "13.0.1",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
   "dependencies": {
     "bootstrap": "^5.3.8",
     "bootstrap-icons": "^1.13.1",
-    "cookie": "^1.0.2",
     "normalize-url": "^8.1.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/src/assets/ts/features/asset/thunks/prepare-to-add-to-screenly.ts
+++ b/src/assets/ts/features/asset/thunks/prepare-to-add-to-screenly.ts
@@ -4,6 +4,7 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 import { AppDispatch, RootState } from '@/types/store';
 import { Cookie, User } from '@/types/core';
 import { getUser } from '@/main';
+import { filterCookiesByOriginDomain } from '@/utils/cookies';
 import { setIsLoading } from '@/features/asset/slice';
 import { openSettings } from '@/features/popup-slice';
 import { proposeToAddToScreenly } from '@/features/asset/thunks/propose-to-add-to-screenly';
@@ -62,10 +63,14 @@ export const prepareToAddToScreenly = createAsyncThunk<
         return;
       }
 
-      const originDomain = new URL(pageUrl).host;
+      const originHostname = new URL(pageUrl).hostname;
 
+      // Include the page URL itself: its cookies matter most for
+      // authentication and it never shows up among its own resource entries.
       const results = await Promise.all(
-        resourceEntries.map((url: string) => browser.cookies.getAll({ url })),
+        [pageUrl, ...resourceEntries].map((url: string) =>
+          browser.cookies.getAll({ url }),
+        ),
       );
 
       let cookieJar = Array.from(
@@ -80,11 +85,7 @@ export const prepareToAddToScreenly = createAsyncThunk<
       ) as Cookie[];
 
       if (onlyPrimaryDomain) {
-        cookieJar = cookieJar.filter(
-          (cookie: Cookie) =>
-            cookie.domain === originDomain ||
-            (!cookie.hostOnly && originDomain.endsWith(cookie.domain)),
-        );
+        cookieJar = filterCookiesByOriginDomain(cookieJar, originHostname);
       }
 
       await dispatch(

--- a/src/assets/ts/features/asset/thunks/submit-asset.ts
+++ b/src/assets/ts/features/asset/thunks/submit-asset.ts
@@ -1,7 +1,6 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { AppDispatch, RootState } from '@/types/store';
-import { Cookie } from '@/types/core';
-import * as cookiejs from 'cookie';
+import { buildCookieHeader } from '@/utils/cookies';
 import {
   getAssetDashboardLink,
   getTeamInfo,
@@ -35,9 +34,7 @@ export const submitAsset = createAsyncThunk<
 
   if (saveAuthentication && proposal.cookieJar) {
     headers = {
-      Cookie: proposal.cookieJar
-        .map((cookie: Cookie) => cookiejs.serialize(cookie.name, cookie.value))
-        .join('; '),
+      Cookie: buildCookieHeader(proposal.cookieJar),
     };
   }
 

--- a/src/assets/ts/utils/cookies.ts
+++ b/src/assets/ts/utils/cookies.ts
@@ -1,0 +1,31 @@
+import { Cookie } from '@/types/core';
+
+// Cookie values from the browser are already in their on-the-wire form, so
+// they must be used verbatim: re-encoding them (e.g. with encodeURIComponent)
+// corrupts values containing characters like `=`, `+`, `/`, or `%`.
+export function buildCookieHeader(cookieJar: Cookie[]): string {
+  return cookieJar
+    .map((cookie: Cookie) => `${cookie.name}=${cookie.value}`)
+    .join('; ');
+}
+
+// Domain cookies are stored with a leading dot (e.g. `.example.com`) and
+// match the apex domain as well as any subdomain. Host-only cookies must
+// match the hostname exactly.
+export function filterCookiesByOriginDomain(
+  cookieJar: Cookie[],
+  originHostname: string,
+): Cookie[] {
+  return cookieJar.filter((cookie: Cookie) => {
+    const cookieDomain = cookie.domain.replace(/^\./, '');
+
+    if (cookie.hostOnly) {
+      return originHostname === cookieDomain;
+    }
+
+    return (
+      originHostname === cookieDomain ||
+      originHostname.endsWith(`.${cookieDomain}`)
+    );
+  });
+}

--- a/src/test/spec/utils/test-cookies.tsx
+++ b/src/test/spec/utils/test-cookies.tsx
@@ -1,0 +1,99 @@
+'use strict';
+
+/// <reference types="jasmine" />
+/* global describe, it, expect */
+
+import {
+  buildCookieHeader,
+  filterCookiesByOriginDomain,
+} from '@/utils/cookies';
+import { Cookie } from '@/types/core';
+
+const makeCookie = (
+  name: string,
+  value: string,
+  domain = 'example.com',
+  hostOnly = false,
+): Cookie => ({ name, value, domain, hostOnly });
+
+describe('buildCookieHeader', function () {
+  it('joins cookies with a semicolon and space', () => {
+    const jar = [makeCookie('a', '1'), makeCookie('b', '2')];
+
+    expect(buildCookieHeader(jar)).toBe('a=1; b=2');
+  });
+
+  it('returns an empty string for an empty jar', () => {
+    expect(buildCookieHeader([])).toBe('');
+  });
+
+  const verbatimValues = [
+    'dG9rZW4=',
+    'a+b/c==',
+    'value%3Dalready%2Fencoded',
+    'left=right',
+  ];
+
+  for (const value of verbatimValues) {
+    it(`keeps ${value} verbatim without re-encoding`, () => {
+      const jar = [makeCookie('session', value)];
+
+      expect(buildCookieHeader(jar)).toBe(`session=${value}`);
+    });
+  }
+});
+
+describe('filterCookiesByOriginDomain', function () {
+  const behaviours: [string, Cookie, string, boolean][] = [
+    [
+      'keeps a host-only cookie on the exact hostname',
+      makeCookie('a', '1', 'app.example.com', true),
+      'app.example.com',
+      true,
+    ],
+    [
+      'drops a host-only cookie from a sibling subdomain',
+      makeCookie('a', '1', 'id.example.com', true),
+      'app.example.com',
+      false,
+    ],
+    [
+      'keeps a domain cookie on a subdomain',
+      makeCookie('a', '1', '.example.com'),
+      'app.example.com',
+      true,
+    ],
+    [
+      'keeps a domain cookie on the apex domain',
+      makeCookie('a', '1', '.example.com'),
+      'example.com',
+      true,
+    ],
+    [
+      'keeps a domain cookie stored without a leading dot',
+      makeCookie('a', '1', 'example.com'),
+      'app.example.com',
+      true,
+    ],
+    [
+      'drops a domain cookie from an unrelated domain',
+      makeCookie('a', '1', '.other.com'),
+      'app.example.com',
+      false,
+    ],
+    [
+      'drops a cookie whose domain is only a suffix of the hostname',
+      makeCookie('a', '1', '.example.com'),
+      'evilexample.com',
+      false,
+    ],
+  ];
+
+  for (const [description, cookie, originHostname, kept] of behaviours) {
+    it(description, () => {
+      const result = filterCookiesByOriginDomain([cookie], originHostname);
+
+      expect(result.length).toBe(kept ? 1 : 0);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Cookie values were re-encoded before being sent as the `Cookie` header, corrupting tokens containing characters like `=`, `+`, `/`, or `%`
- Consolidates cookie handling into a small utility (`src/assets/ts/utils/cookies.ts`) that preserves values verbatim and centralizes domain-matching logic
- Cookies are now gathered for the page URL itself in addition to its resource entries
- Fixes domain matching for the primary-domain-only filter (hostname-based instead of host-based, correct handling of apex/subdomain and host-only cookies)
- Removes the now-unused `cookie` npm dependency

## Test plan
- [x] Added unit tests covering verbatim serialization and domain-matching behavior (`src/test/spec/utils/test-cookies.tsx`)
- [x] `npm test` passes (29 specs, 0 failures)
- [x] `npm run lint:check` and `npm run format:check` pass
- [x] `npm run build` compiles cleanly